### PR TITLE
Upgrade gelf-pro from 1.3.3 to 1.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -930,6 +930,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
       "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -2367,12 +2368,18 @@
       "dev": true
     },
     "gelf-pro": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.3.3.tgz",
-      "integrity": "sha512-gohbipAj/okE7pUgRSkIMEiqAS2M3q5YWnoejUDA9qwBeqbJr8LSwe3E7YW2QFK7hi4tZje1ZnKQe0296zdW/w==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.3.11.tgz",
+      "integrity": "sha512-y6DOxU40U4Sd+ECSLtMMtOTig1gEmnIHnvfocyvH+okc6LSfd7ADirT1tbzpAMzOXIgDG/2j9psZ1ck3HXfjEA==",
       "requires": {
-        "async": "2.6.2",
-        "lodash": "4.17.14"
+        "lodash": "~4.17.21"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "gensync": {
@@ -3705,7 +3712,8 @@
     "lodash": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "winston": "3.2.1"
   },
   "dependencies": {
-    "gelf-pro": "1.3.3",
+    "gelf-pro": "1.3.11",
     "logform": "2.1.2",
     "winston-transport": "4.3.0"
   },


### PR DESCRIPTION
I noticed that the latest commit of this repo was made almost three years ago. Nevertheless, I decided to make this PR. This package is still downloaded over 1,500 times a week according to npm. I'm also a user of this package as I think it's the best alternative for the job.

Please accept this PR to fix four (not dev dependency) vulnerabilties classified as **high** or **moderate**:

- [async < 2.6.4](https://github.com/advisories/GHSA-fwr7-v2mv-hh25) (**high**)
- [lodash < 4.17.21](https://github.com/advisories/GHSA-35jh-r3h4-6jhm) (**high**)
- [lodash < 4.17.19](https://github.com/advisories/GHSA-p6mc-m468-83gw) (**high**)
- [lodash < 4.17.21](https://github.com/advisories/GHSA-29mw-wpgm-hmr9) (**moderate**)

Thanks in advance!